### PR TITLE
fix: Centralize known extensions and add UnzipAndFlatten

### DIFF
--- a/RommPlugin.Core/Models/Statics/KnownExtensions.cs
+++ b/RommPlugin.Core/Models/Statics/KnownExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RommPlugin.Core.Models.Statics
+{
+    public static class KnownExtensions
+    {
+        public static readonly HashSet<string> Extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".zip", ".7z", ".rar",
+            ".iso", ".cue", ".bin", ".img",
+            ".chd", ".cso",
+            ".nes", ".sfc", ".smc", ".gba",
+            ".gb", ".gbc", ".n64", ".z64", ".v64",
+            ".nds", ".3ds",
+            ".gcz", ".nkit",
+            ".xiso", ".xci", ".rvz",
+            ".vpx", ".wad", ".wux"
+        };
+    }
+}

--- a/RommPlugin.Core/RommPlugin.Core.csproj
+++ b/RommPlugin.Core/RommPlugin.Core.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Models\RommPlatform.cs" />
     <Compile Include="Models\RommSyncEvent.cs" />
     <Compile Include="Models\RommSyncFile.cs" />
+    <Compile Include="Models\Statics\KnownExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\RommPluginStorage.cs" />
   </ItemGroup>

--- a/RommPlugin/Services/RommProcessInstallUninstallService.cs
+++ b/RommPlugin/Services/RommProcessInstallUninstallService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
@@ -94,14 +95,14 @@ namespace RommPlugin.Services
                                     fileName
                                 );
 
+                                var zipPath = localFile;
+                                var extractDir = Path.Combine(
+                                    Path.GetDirectoryName(zipPath),
+                                    Path.GetFileNameWithoutExtension(zipPath)
+                                );
+
                                 if (isFolderGame)
                                 {
-                                    var zipPath = localFile;
-                                    var extractDir = Path.Combine(
-                                        Path.GetDirectoryName(zipPath),
-                                        Path.GetFileNameWithoutExtension(zipPath)
-                                    );
-
                                     UnzipAndDelete(zipPath, extractDir);
 
                                     var jsonPath = Path.Combine(extractDir, "_launchbox.json");
@@ -116,6 +117,8 @@ namespace RommPlugin.Services
                                 }
                                 else
                                 {
+                                    UnzipAndFlatten(zipPath);
+
                                     installed = File.Exists(localFile);
                                     game.ApplicationPath = installed ? localFile : null;
                                 }
@@ -281,6 +284,36 @@ namespace RommPlugin.Services
             }
 
             File.Delete(zipPath);
+        }
+
+        private void UnzipAndFlatten(string zipPath)
+        {
+            if (File.Exists(zipPath) && Path.GetExtension(zipPath).Equals(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                var tempExtract = Path.Combine(
+                    Path.GetDirectoryName(zipPath),
+                    "__temp_extract"
+                );
+
+                if (Directory.Exists(tempExtract))
+                {
+                    Directory.Delete(tempExtract, true);
+                }    
+
+                Directory.CreateDirectory(tempExtract);
+
+                ZipFile.ExtractToDirectory(zipPath, tempExtract);
+
+                var innerFile = Directory.GetFiles(tempExtract, "*.zip", SearchOption.AllDirectories)
+                    .FirstOrDefault();
+
+                if (innerFile != null)
+                {
+                    File.Copy(innerFile, zipPath, true);
+                }
+
+                Directory.Delete(tempExtract, true);
+            }
         }
     }
 }

--- a/RommPlugin/Services/RommSyncService.cs
+++ b/RommPlugin/Services/RommSyncService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using RommPlugin.ApiClient;
 using RommPlugin.Core.Models;
+using RommPlugin.Core.Models.Statics;
 using RommPlugin.Core.Storage;
 using RommPlugin.UI.Forms;
 using RommPlugin.UI.Helpers;
@@ -226,19 +227,6 @@ namespace RommPlugin.Services
             return int.TryParse(value, out var id) ? id : 0;
         }
 
-        private static readonly HashSet<string> KnownExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ".zip", ".7z", ".rar",
-            ".iso", ".cue", ".bin", ".img",
-            ".chd", ".cso",
-            ".nes", ".sfc", ".smc", ".gba",
-            ".gb", ".gbc", ".n64", ".z64", ".v64",
-            ".nds", ".3ds",
-            ".gcz", ".nkit",
-            ".xiso", ".xci", ".rvz",
-            ".vpx", ".wad", ".wux"
-        };
-
         public object RoomImageService { get; private set; }
 
         private string NormalizeGameTitle(string name)
@@ -253,7 +241,7 @@ namespace RommPlugin.Services
             while (true)
             {
                 var ext = Path.GetExtension(cleaned);
-                if (string.IsNullOrEmpty(ext) || !KnownExtensions.Contains(ext))
+                if (string.IsNullOrEmpty(ext) || !KnownExtensions.Extensions.Contains(ext))
                 {
                     break;
                 }


### PR DESCRIPTION
Move known file extensions to a new static class for reuse and clarity. Add UnzipAndFlatten method to handle nested zip files during install. Refactor related code for maintainability.