### PR TITLE
fix: Some null problems in launchbox_metadata and read only servers

### DIFF
--- a/RommPlugin.Core/Models/RommUpdateGameRequest.cs
+++ b/RommPlugin.Core/Models/RommUpdateGameRequest.cs
@@ -6,8 +6,6 @@ namespace RommPlugin.Core.Models
     {
         public string Name { get; set; }
 
-        public string FsName { get; set; }
-
         public string Summary { get; set; }
 
         public int? LaunchboxId { get; set; }

--- a/RommPlugin/ApiClient/RommApiClient.cs
+++ b/RommPlugin/ApiClient/RommApiClient.cs
@@ -92,54 +92,81 @@ namespace RommPlugin.ApiClient
             {
                 var content = new MultipartFormDataContent();
 
-                    content.Add(new StringContent(request.Name ?? ""), "name");
-                    content.Add(new StringContent(request.FsName ?? ""), "fs_name");
-                    content.Add(new StringContent(request.Summary ?? ""), "summary");
-                    content.Add(new StringContent(request.LaunchboxId?.ToString() ?? ""), "launchbox_id");
+                content.Add(new StringContent(request.Name ?? ""), "name");
+                content.Add(new StringContent(request.Summary ?? ""), "summary");
+                content.Add(new StringContent(request.LaunchboxId?.ToString() ?? ""), "launchbox_id");
 
-                    var launchboxJson = JsonConvert.SerializeObject(request.RawLaunchboxMetadata);
-                    content.Add(new StringContent(launchboxJson, Encoding.UTF8, "application/json"), "raw_launchbox_metadata");
+                if (request.RawLaunchboxMetadata != null)
+                {
+                    ReplaceNullStrings(request.RawLaunchboxMetadata);
+                }
 
-                    if (!string.IsNullOrEmpty(request.ArtworkPath))
+                var launchboxJson = JsonConvert.SerializeObject(
+                    request.RawLaunchboxMetadata,
+                    new JsonSerializerSettings
                     {
-                        using (var fileStream = File.OpenRead(request.ArtworkPath))
+                        NullValueHandling = NullValueHandling.Ignore
+                    }
+                );
+
+                content.Add(new StringContent(launchboxJson, Encoding.UTF8, "application/json"), "raw_launchbox_metadata");
+
+                if (!string.IsNullOrEmpty(request.ArtworkPath))
+                {
+                    using (var fileStream = File.OpenRead(request.ArtworkPath))
+                    {
+                        var fileContent = new StreamContent(fileStream);
+
+                        fileContent.Headers.ContentType =
+                            new MediaTypeHeaderValue(GetMimeType(request.ArtworkPath));
+
+                        content.Add(
+                            fileContent,
+                            "artwork",
+                            Path.GetFileName(request.ArtworkPath)
+                        );
+
+                        var response = await _http.PutAsync(
+                            $"api/roms/{gameId}?remove_cover=false&unmatch_metadata=false",
+                            content
+                        );
+
+                        if (!response.IsSuccessStatusCode)
                         {
-                            var fileContent = new StreamContent(fileStream);
-                            fileContent.Headers.ContentType = new MediaTypeHeaderValue(GetMimeType(request.ArtworkPath));
-
-                            content.Add(fileContent, "artwork", Path.GetFileName(request.ArtworkPath));
-
-                            var response = await _http.PutAsync(
-                                $"api/roms/{gameId}?remove_cover=false&unmatch_metadata=false",
-                                content
-                            );
-
-                            if (!response.IsSuccessStatusCode)
+                            if ((int)response.StatusCode >= 500)
                             {
-                                if ((int)response.StatusCode >= 500)
+                                if (attempt == maxAttempts)
                                 {
-                                    if (attempt == maxAttempts)
-                                    {
-                                        throw new HttpRequestException($"Server error {(int)response.StatusCode}");
-                                    }
-
-                                    await Task.Delay(500 * attempt);
-                                    continue;
+                                    throw new HttpRequestException($"Server error {(int)response.StatusCode}");
                                 }
 
-                                response.EnsureSuccessStatusCode();
+                                await Task.Delay(500 * attempt);
+                                continue;
                             }
-                        }
-                    }
 
+                            response.EnsureSuccessStatusCode();
+                        }
+
+                        return;
+                    }
+                }
+                else
+                {
+                    var response = await _http.PutAsync(
+                        $"api/roms/{gameId}?remove_cover=false&unmatch_metadata=false",
+                        content
+                    );
+
+                    response.EnsureSuccessStatusCode();
                     return;
+                }
             }
         }
 
         public async Task RemoveGameMetadataById(int gameId)
         {
             var response = await _http.PutAsync($"api/roms/{gameId}?remove_cover=false&unmatch_metadata=true", null);
-            
+
             response.EnsureSuccessStatusCode();
             return;
         }
@@ -182,5 +209,28 @@ namespace RommPlugin.ApiClient
 
             return "application/octet-stream";
         }
+
+        private void ReplaceNullStrings(object obj)
+            {
+                if (obj == null)
+                {
+                    return;
+                }
+
+                var properties = obj.GetType().GetProperties();
+
+                foreach (var prop in properties)
+                {
+                    if (prop.PropertyType == typeof(string))
+                    {
+                        var value = (string)prop.GetValue(obj);
+
+                        if (value == null)
+                        {
+                            prop.SetValue(obj, "");
+                        }
+                    }
+                }
+            }
     }
 }

--- a/RommPlugin/Services/RommSyncService.cs
+++ b/RommPlugin/Services/RommSyncService.cs
@@ -486,7 +486,6 @@ namespace RommPlugin.Services
                         var request = new RommUpdateGameRequest
                         {
                             Name = game.Title,
-                            FsName = serverGame.FsName,
                             Summary = game.Notes,
                             LaunchboxId = game.LaunchBoxDbId,
                             RawLaunchboxMetadata = LaunchboxMetadaService.BuildLaunchboxMetadata(game),


### PR DESCRIPTION
fix: Some null problems in launchbox_metadata and read only servers

Remove FsName from update request and refactor API logic

Removed FsName from RommUpdateGameRequest and all usages. Updated RommApiClient to exclude FsName, handle null strings in RawLaunchboxMetadata, and ignore nulls during JSON serialization. Refactored artwork upload and HTTP response handling for clarity and retries. Added ReplaceNullStrings helper. Updated RommSyncService to remove FsName assignment.