### PR TITLE
fix: Refactor folder game check and improve archive extraction

### DIFF
--- a/RommPlugin.CLI/RommInstaller.cs
+++ b/RommPlugin.CLI/RommInstaller.cs
@@ -50,7 +50,7 @@ namespace RommPlugin.CLI
 
                 Directory.CreateDirectory(localDir);
 
-                var isFolderGame = game.Files.Count > 1;
+                var isFolderGame = game.HasMultipleFiles;
 
                 var localFile = Path.Combine(localDir, game.FsName + (isFolderGame ? ".zip" : ""));
 

--- a/RommPlugin/Services/RommProcessInstallUninstallService.cs
+++ b/RommPlugin/Services/RommProcessInstallUninstallService.cs
@@ -284,7 +284,9 @@ namespace RommPlugin.Services
 
                     if (parts.Length == 0)
                     {
-                        continue;
+                        parts = entry.FullName
+                            .Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
+                            .ToArray();
                     }
 
                     var relativePath = Path.Combine(parts);

--- a/RommPlugin/Services/RommSyncService.cs
+++ b/RommPlugin/Services/RommSyncService.cs
@@ -190,7 +190,7 @@ namespace RommPlugin.Services
 
                                 game.Platform = platform.Name;
 
-                                var isFolderGame = rommGame.Files.Count > 1;
+                                var isFolderGame = rommGame.HasMultipleFiles;
 
                                 SetCustomField(game, GameCustomFields.GameId, rommGame.Id.ToString());
                                 SetCustomField(game, GameCustomFields.PlatformId, rommPlatform.Id.ToString());
@@ -324,7 +324,7 @@ namespace RommPlugin.Services
                 game.Platform = platformName;
             }
 
-            var isFolderGame = rommGame.Files.Count > 1;
+            var isFolderGame = rommGame.HasMultipleFiles;
 
             SetCustomField(game, GameCustomFields.RemotePath, rommGame.FsPath ?? "");
             SetCustomField(game, GameCustomFields.FileName, (rommGame.FsName + (isFolderGame ? ".zip" : "")) ?? "");


### PR DESCRIPTION
fix: Refactor folder game check and improve archive extraction

Replaced `Files.Count > 1` with `HasMultipleFiles` for clarity and encapsulation across the codebase. Updated archive extraction logic in `RommProcessInstallUninstallService.cs` to ensure path parts are always populated, preventing extraction errors.